### PR TITLE
Fix: Window background texture dispose

### DIFF
--- a/KpRefresher/KpRefresher.cs
+++ b/KpRefresher/KpRefresher.cs
@@ -243,7 +243,6 @@ namespace KpRefresher
             _cornerIconContextMenu?.Dispose();
             _apiSpinner?.Dispose();
             _mainWindow?.Dispose();
-            _windowBackgroundTexture?.Dispose();
             _emblemTexture?.Dispose();
 
             // All static members must be manually unset


### PR DESCRIPTION
- removed disposal of asset cache texture for window background, so other modules can continue to use the texture.
---
After loading and unloading your module, I noticed the background texture of the window of another module was missing (transparent). This is caused by disposing a texture from the (shared) `DatAssetCache`.

> [!CAUTION]
> Do not dispose of textures received from the DatAssetCache. These textures are shared between modules and with core. Blish HUD itself manages the lifecycle of these textures.

(Reference: [Blish HUD Module Dev Guide](https://blishhud.com/docs/modules/guides/textures#guild-wars-2-asset-textures-datassetcache)).

For the main window background texture you use `_windowBackgroundTexture = AsyncTexture2D.FromAssetId(155985);`. (see [KpRefresher.cs](https://github.com/OlivierCharton/KpRefresher/blob/f8bc5d5be9347a5f2625c24f01f3da610bde6a3a/KpRefresher/KpRefresher.cs#L106))

`AsyncTexture2D.FromAssetId(int assetId)` is just a wrapper for `GameService.Content.DatAssetCache.GetTextureFromAssetId(int assetId)`.

This issue is fixed by just removing the disposal of the `_windowBackgroundTexture`.
